### PR TITLE
[libsignon-qt] Use INT_MAX timeout for signon dbus

### DIFF
--- a/rpm/0001-Partial-backport-of-lib-set-timeout-for-D-Bus-calls-.patch
+++ b/rpm/0001-Partial-backport-of-lib-set-timeout-for-D-Bus-calls-.patch
@@ -1,0 +1,40 @@
+From af9c517536a7cd51affd6d22332d90864dff51f2 Mon Sep 17 00:00:00 2001
+From: Alberto Mardegan <alberto.mardegan@canonical.com>
+Date: Fri, 6 Sep 2013 09:33:01 +0300
+Subject: [PATCH] Partial backport of lib: set timeout for D-Bus calls to
+ INT_MAX
+
+QDBusAbstractInterface uses the default D-Bus timeout (about 30 seconds)
+unless instructed otherwise. But when UI-interactions are involved, the
+authentication process can last longer than that.
+This commit sets the timeout to INT_MAX.
+
+Fixes: https://bugs.launchpad.net/bugs/1220823
+---
+ lib/SignOn/dbusinterface.cpp |    3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/lib/SignOn/dbusinterface.cpp b/lib/SignOn/dbusinterface.cpp
+index 4c63fb6..b580bed 100644
+--- a/lib/SignOn/dbusinterface.cpp
++++ b/lib/SignOn/dbusinterface.cpp
+@@ -22,6 +22,8 @@
+ 
+ #include "dbusinterface.h"
+ 
++#include <climits>
++
+ using namespace SignOn;
+ 
+ DBusInterface::DBusInterface(const QString &service,
+@@ -31,6 +33,7 @@ DBusInterface::DBusInterface(const QString &service,
+                              QObject *parent):
+     QDBusAbstractInterface(service, path, interface, connection, parent)
+ {
++    setTimeout(INT_MAX);
+ }
+ 
+ DBusInterface::~DBusInterface()
+-- 
+1.7.9.5
+

--- a/rpm/libsignon-qt.spec
+++ b/rpm/libsignon-qt.spec
@@ -6,6 +6,7 @@ Group: System/Libraries
 License: LGPLv2.1
 URL: https://code.google.com/p/accounts-sso.signond/
 Source0: %{name}-%{version}.tar.bz2
+Patch0: 0001-Partial-backport-of-lib-set-timeout-for-D-Bus-calls-.patch
 BuildRequires: doxygen
 BuildRequires: pkgconfig(QtCore)
 BuildRequires: pkgconfig(dbus-1)
@@ -84,6 +85,8 @@ Obsoletes: libsignon-doc < %{version}-%{release}
 
 %prep
 %setup -q -n %{name}-%{version}/libsignon
+
+%patch0 -p1
 
 chmod +x tests/create-tests-definition.sh
 

--- a/rpm/libsignon-qt5.spec
+++ b/rpm/libsignon-qt5.spec
@@ -6,6 +6,7 @@ Group: System/Libraries
 License: LGPLv2.1
 URL: https://code.google.com/p/accounts-sso.signond/
 Source0: %{name}-%{version}.tar.bz2
+Patch0: 0001-Partial-backport-of-lib-set-timeout-for-D-Bus-calls-.patch
 BuildRequires: doxygen
 BuildRequires: pkgconfig(Qt5Core)
 BuildRequires: pkgconfig(Qt5DBus)
@@ -158,6 +159,8 @@ This package contains tests for signon
 
 %prep
 %setup -q -n %{name}-%{version}/libsignon
+
+%patch0 -p1
 
 chmod +x tests/create-tests-definition.sh
 


### PR DESCRIPTION
The process may take a very long time when waiting on user input. DBus
shouldn't time the call out automatically.
