### PR TITLE
[signon] Continue reading from plugins after handling response if necessary

### DIFF
--- a/libsignon/src/signond/pluginproxy.cpp
+++ b/libsignon/src/signond/pluginproxy.cpp
@@ -436,6 +436,10 @@ void PluginProxy::handlePluginResponse(const quint32 resultOperation,
     }
 
     connect(m_process, SIGNAL(readyRead()), this, SLOT(onReadStandardOutput()));
+    if (m_process->bytesAvailable()) {
+        TRACE() << "plugin has more to read after handling a response";
+        onReadStandardOutput();
+    }
 }
 
 void PluginProxy::onReadStandardError()


### PR DESCRIPTION
There may be more than one response from the plugin; for example, during
a refresh, you receive a store and result response. If both arrive
simultaniously, readyRead() will not be signalled again after handling
the first response. The request will then be deadlocked waiting for a
response that is sitting in the file buffer.

The immediate solution is simply to read again if there's more to be
read after handling a response.
