### PR TITLE
[signond] Initialize private member ptr in ctor to avoid crash

### DIFF
--- a/libsignon/src/signond/default-secrets-storage.h
+++ b/libsignon/src/signond/default-secrets-storage.h
@@ -95,6 +95,7 @@ public:
 
 private:
     SecretsDB *m_secretsDB;
+    QString m_secretsDBConnectionName;
 };
 
 } //namespace


### PR DESCRIPTION
This commit initializes the m_secretsDB member of the default secrets
storage class to avoid spurious close() on invalid pointer.

It also ensures that the database name and connection name strings
for the default secrets storage database are detached from their
source strings, in case their source string is a QStringLiteral which
comes from a plugin which gets unloaded prior to the dtor being called.