### PR TITLE
[signond] Use peer-to-peer dbus connections for signon

### DIFF
--- a/rpm/libsignon-qt5.spec
+++ b/rpm/libsignon-qt5.spec
@@ -172,7 +172,7 @@ This package contains tests for signon
 chmod +x tests/create-tests-definition.sh
 
 %build
-%qmake5 TESTDIR=/opt/tests/signon CONFIG+=install_tests
+%qmake5 TESTDIR=/opt/tests/signon CONFIG+=install_tests CONFIG+=enable-p2p
 make %{?_smp_mflags}
 
 


### PR DESCRIPTION
This commit ensures that we use peer-to-peer dbus connections instead
of the session bus between signond and the client process requesting
signon.