### PR TITLE
[signond] Retarget upstream repo url. Contributes to MER#908

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "upstream"]
 	path = upstream
-	url = https://code.google.com/p/accounts-sso.signond/
+	url = https://gitlab.com/accounts-sso/signond.git

--- a/rpm/libsignon-qt5.spec
+++ b/rpm/libsignon-qt5.spec
@@ -4,7 +4,7 @@ Release: 3
 Summary: Single Sign On framework
 Group: System/Libraries
 License: LGPLv2.1
-URL: https://code.google.com/p/accounts-sso.signond/
+URL: https://gitlab.com/accounts-sso/signond
 Source0: %{name}-%{version}.tar.bz2
 BuildRequires: doxygen
 BuildRequires: pkgconfig(Qt5Core)


### PR DESCRIPTION
The upstream repository url has changed from code.google.com to gitlab
due to the imminent closure of code.google.com.

Contributes to MER#908